### PR TITLE
Fixed InsertGetId for redshift.

### DIFF
--- a/src/Database/Query/Grammars/RedshiftGrammar.php
+++ b/src/Database/Query/Grammars/RedshiftGrammar.php
@@ -2,8 +2,21 @@
 namespace YuK1\LaravelRedshift\Database\Query\Grammars;
 
 use Illuminate\Database\Query\Grammars\PostgresGrammar;
+use Illuminate\Database\Query\Builder;
 
 class RedshiftGrammar extends PostgresGrammar
 {
-
+    /**
+     * Compile insert statement.
+     * Unlike PostgreSQL, in Redshift it is not possible to return the id at the same time
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $values
+     * @param  string  $sequence
+     * @return string
+     */
+    public function compileInsertGetId(Builder $query, $values, $sequence)
+    {
+        return $this->compileInsert($query, $values);
+    }
 }

--- a/src/Database/Query/Processors/RedshiftProcessor.php
+++ b/src/Database/Query/Processors/RedshiftProcessor.php
@@ -2,8 +2,30 @@
 namespace YuK1\LaravelRedshift\Database\Query\Processors;
 
 use Illuminate\Database\Query\Processors\PostgresProcessor;
+use Illuminate\Database\Query\Builder;
 
 class RedshiftProcessor extends PostgresProcessor
 {
+    /**
+     * Process an "insert get ID" query.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  string  $sql
+     * @param  array  $values
+     * @param  string|null  $sequence
+     * @return int
+     */
+    public function processInsertGetId(Builder $query, $sql, $values, $sequence = null)
+    {
+        $connection = $query->getConnection();
 
+        $connection->insert($sql, $values);
+
+        $idColumn = $sequence ?: 'id';
+        $wrappedTable = $query->getGrammar()->wrapTable($query->from);
+        $result = $connection->selectOne('select max('. $idColumn .') from '.$wrappedTable);
+        $id = array_values((array) $result)[0];
+
+        return is_numeric($id) ? (int) $id : $id;
+    }
 }


### PR DESCRIPTION
In PostGreSQL it is possible to add `returning id` to an insert query to get the auto incremented id afterwards. Although redshift is derived from postgresql, in redshift this syntax is not supported.


Syntax error: 7 ERROR:  syntax error at or near "returning"
LINE 1: ..._at") values ($1, $2, $3, $4, $5, $6, $7, $8, $9) returning ...
                                                             ^ (SQL: insert into "caraai_writeback_tableau_v1" ("alert_id", "status", "reason", "assignee", "comment", "email_sent", "user_id", "updated_at", "created_at") values (abcdefg, Open, False Positive, Hakan Kilic, ?, 0, 5, 2023-07-08 02:34:27, 2023-07-08 02:34:27) returning "id") 
