### PR TITLE
Fixed fetching schemas for redshift. postgresql schema grammar change…

### DIFF
--- a/src/Database/Schema/Grammars/RedshiftGrammar.php
+++ b/src/Database/Schema/Grammars/RedshiftGrammar.php
@@ -133,4 +133,15 @@ class RedshiftGrammar extends PostgresGrammar
   {
     return 'char(36)';
   }
+
+  /**
+   * Compile the SQL needed to retrieve all table names.
+   *
+   * @param  string|array  $searchPath
+   * @return string
+   */
+  public function compileGetAllTables($searchPath)
+  {
+    return "select tablename from pg_catalog.pg_tables where schemaname in ('".implode("','", (array) $searchPath)."')";
+  }
 }


### PR DESCRIPTION
They changed the query &*!*%#$%^$!#

new query does not work in redshifty

https://github.com/laravel/framework/blob/8.x/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php#L306

https://github.com/laravel/framework/blob/10.x/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php#L381

